### PR TITLE
reword docs, rename param, expand tests

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,7 +194,7 @@ Forecasting:
 Preprocessing:
 --------------
 
-- :doc:`api_doc/preprocessing/MatchCategories`: encodes categorical columns are of 'category' type
+- :doc:`api_doc/preprocessing/MatchCategories`: ensures categorical variables are of type 'category'
 - :doc:`api_doc/preprocessing/MatchVariables`: ensures that columns in test set match those in train set
 
 Scikit-learn Wrapper:

--- a/docs/user_guide/preprocessing/MatchCategories.rst
+++ b/docs/user_guide/preprocessing/MatchCategories.rst
@@ -6,21 +6,21 @@ MatchCategories
 ===============
 
 :class:`MatchCategories()` ensures that categorical variables are encoded as pandas
-'categorical' dtype, instead of generic python 'object' or other dtypes.
+'categorical' dtype instead of generic python 'object' or other dtypes.
 
 Under the hood, 'categorical' dtype is a representation that maps each
 category to an integer, thus providing a more memory-efficient object
-structure than e.g., 'str', and allowing faster grouping, mapping, and similar
+structure than, for example, 'str', and allowing faster grouping, mapping, and similar
 operations on the resulting object.
 
-MatchCategories() remembers the encodings or levels that represent each
+:class:`MatchCategories()` remembers the encodings or levels that represent each
 category, and can thus can be used to ensure that the correct encoding gets
 applied when passing categorical data to modeling packages that support this
 dtype, or to prevent unseen categories from reaching a further transformer
 or estimator in a pipeline, for example.
 
 Let's explore this with an example. First we load the Titanic dataset and split it into
-a train and a test set:
+a train and a test sets:
 
 .. code:: python
 
@@ -119,10 +119,9 @@ dataset:
     Index(['C', 'Q', 'S'], dtype='object')
 
 
-
-If some category was not present in the training data, it will not map
-to any integer and will this not get encoded (behavior here depends on what one
-passed for 'errors'):
+If some category was not present in the training data, it will not mapped
+to any integer and will thus not get encoded. This behavior can be modified through the
+parameter `errors`:
 
 .. code:: python
 
@@ -165,7 +164,6 @@ passed for 'errors'):
 When to use the transformer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
 This transformer is useful when creating custom transformers for categorical columns,
 as well as when passing categorical columns to modeling packages that support them
-natively but which leaving their encoding to the user.
+natively but leave the variable casting to the user.

--- a/feature_engine/preprocessing/match_categories.py
+++ b/feature_engine/preprocessing/match_categories.py
@@ -14,7 +14,6 @@ from feature_engine.encoding._docstrings import (
     _ignore_format_docstring,
     _variables_docstring,
 )
-from feature_engine.encoding._helper_functions import check_parameter_errors
 from feature_engine.encoding.base_encoder import (
     CategoricalInitMixin,
     CategoricalMethodsMixin,

--- a/feature_engine/preprocessing/match_categories.py
+++ b/feature_engine/preprocessing/match_categories.py
@@ -45,6 +45,8 @@ class MatchCategories(CategoricalInitMixin, CategoricalMethodsMixin):
     dtype, or to prevent unseen categories from reaching a further transformer
     or estimator in a pipeline, for example.
 
+    More details in the :ref:`User Guide <match_categories>`.
+
     Parameters
     ----------
     {variables}

--- a/tests/test_preprocessing/test_check_estimator_preprocessing.py
+++ b/tests/test_preprocessing/test_check_estimator_preprocessing.py
@@ -2,9 +2,9 @@ import pytest
 from sklearn.utils.estimator_checks import check_estimator
 
 from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
-from feature_engine.preprocessing import MatchVariables
+from feature_engine.preprocessing import MatchCategories, MatchVariables
 
-_estimators = [MatchVariables()]
+_estimators = [MatchCategories(ignore_format=True), MatchVariables()]
 
 
 @pytest.mark.parametrize("estimator", _estimators)
@@ -12,6 +12,6 @@ def test_check_estimator_from_sklearn(estimator):
     return check_estimator(estimator)
 
 
-@pytest.mark.parametrize("estimator", _estimators)
+@pytest.mark.parametrize("estimator", [MatchCategories(), MatchVariables()])
 def test_check_estimator_from_feature_engine(estimator):
     return check_feature_engine_estimator(estimator)


### PR DESCRIPTION
Hi @david-cortes 

**Main change**: I renamed the parameter errors to missing_values.

`errors` is an unhappy choice of name on our side for the encoders that refers to **unseen categories**. So we need to change that in a future commit.

You class is not talking about unseen categories, rather NA themselves, so `missing_values` is a better name for that.

Other than that, I did minor re-wording, and expanded the tests a little.

This is good to go from my side. So if you merge here, then I merge in the main repo.

Thanks a lot for your contribution.

Cheers
